### PR TITLE
Add autoPreFetch to Link

### DIFF
--- a/frontity.settings.js
+++ b/frontity.settings.js
@@ -19,6 +19,7 @@ const settings = {
           ],
           logo:
             "https://demo-wp.alexaspalato.website/wp-content/uploads/2020/02/logo.svg",
+          autoPreFetch: "hover",
           showSocialLinks: {
             header: false,
             footer: true

--- a/packages/frontity-starter-theme/src/components/link.js
+++ b/packages/frontity-starter-theme/src/components/link.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { connect } from "frontity";
 
 const Link = ({
@@ -7,17 +7,32 @@ const Link = ({
   link,
   className,
   children,
-  "aria-current": ariaCurrent
+  rel,
+  "aria-current": ariaCurrent,
+  onClick: onClickProp
 }) => {
-  const onClick = e => {
-    // Do nothing if it's an external link
-    if (link.startsWith("http")) return;
-    e.preventDefault();
+  // Check if the link is an external or internal link.
+  const isExternal = link.startsWith("http");
+
+  // Prefetch the link's content when autoPreFetch is set to "all".
+  useEffect(() => {
+    if (!isExternal) {
+      if (state.theme.autoPreFetch === "all") actions.source.fetch(link);
+    }
+  }, []);
+
+  const onClick = event => {
+    // Do nothing if it's an external link.
+    if (isExternal) return;
+
+    event.preventDefault();
     // Set the router to the new url.
     actions.router.set(link);
-    // Scroll the page to the top
+
+    // Scroll the page to the top.
     window.scrollTo(0, 0);
-    // if the menu modal is open, close it so it doesn't block rendering
+
+    // If the menu modal is open, close it so it doesn't block rendering.
     if (state.theme.isMobileMenuOpen) {
       actions.theme.closeMobileMenu();
     }
@@ -29,6 +44,12 @@ const Link = ({
       onClick={onClick}
       className={className}
       aria-current={ariaCurrent}
+      rel={isExternal ? "noopener noreferrer" : rel}
+      onMouseEnter={() => {
+        // Prefetch the link's content when the user hovers on the link.
+        if (state.theme.autoPreFetch === "hover" && !isExternal)
+          actions.source.fetch(link);
+      }}
     >
       {children}
     </a>

--- a/packages/frontity-starter-theme/src/index.js
+++ b/packages/frontity-starter-theme/src/index.js
@@ -24,7 +24,7 @@ const testTheme = {
       },
       socialLinks: [],
       isMobileMenuOpen: false,
-      autoPreFetch: "all",
+      autoPreFetch: "none",
       featured: {
         showOnArchive: true,
         showOnPost: true


### PR DESCRIPTION
I've added `autoPreFetch` in a similar way to what we have in the TwentyTwenty theme and it includes other changes, but this is where the magic happens:
```js
onMouseEnter={() => {
  // Prefetch the link's content when the user hovers on the link.
  if (state.theme.autoPreFetch === "hover" && !isExternal)
    actions.source.fetch(link);
}}
```
We do `actions.source.fetch` of the link if the setting is `hover` and it's not an external link. It's that simple.
